### PR TITLE
Fix typo in package sort option

### DIFF
--- a/app/controllers/packages/search.js
+++ b/app/controllers/packages/search.js
@@ -20,7 +20,7 @@ export default Ember.Controller.extend(BaseControllerMixin, PaginationSupportMix
       { value: 'score', label: 'Sort by relevance'},
       { value: 'title', label: 'Sort by title'},
       { value: 'id', label: 'Sort by package ID'},
-      { value: 'published', label: 'Sory by date published'}
+      { value: 'published', label: 'Sort by date published'}
     ],
 
     latestOnlyFilters: [


### PR DESCRIPTION
I know it's not much, but fixed the typo as mentioned in Issue #161.
Closes #161